### PR TITLE
Refactor TODO comments to use pipe delimiter 

### DIFF
--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/.github/CODEOWNERS
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# TODO: Update Default Code Owners for pull request notifications
+# TODO| Update Default Code Owners for pull request notifications
 
 # Default owners for everything in the repo.
 # Unless a later match takes precedence, these owners will be requested for review when someone opens a pull request.

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/.github/settings.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/.github/settings.yml
@@ -1,5 +1,5 @@
 ---
-# TODO: Verify the GitHub Settings App (https://github.com/apps/settings) is installed
+# TODO| Verify the GitHub Settings App (https://github.com/apps/settings) is installed
 #       to enable repository settings management via this configuration file.
 
 # These settings are synced to GitHub by https://probot.github.io/apps/settings

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/README.md
@@ -8,35 +8,35 @@
 
 {{ cookiecutter.collection_description }}
 
-<!-- TODO: ## Code of Conduct
+<!-- TODO| ## Code of Conduct
 
 We follow the [Ansible Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html) in all our interactions within this project.
 
 If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
 -->
 
-<!-- TODO: ## Collection maintenance
+<!-- TODO| ## Collection maintenance
 
 The current maintainers are listed in the [CODEOWNERS](https://github.com/{{ cookiecutter.scm_repository | replace("https://github.com/", "") }}/.github/CODEOWNERS)) file. If you have questions or need help, feel free to mention them in the proposals.
 
 To learn how to maintain / become a maintainer of this collection, refer to the [Maintainer guidelines](MAINTAINING.md).
 -->
 
-<!-- TODO: ## Tested with Ansible
+<!-- TODO| ## Tested with Ansible
 List the versions of Ansible the collection has been tested with.e
 Must match what is in galaxy.yml.
 -->
 
-<!-- TODO: ## External requirements
+<!-- TODO| ## External requirements
 List any external resources the collection depends on, for example minimum versions of an OS, libraries, or utilities.
 Do not list other Ansible collections here.
 -->
 
-<!-- TODO: ## Supported connections (Optional)
+<!-- TODO| ## Supported connections (Optional)
 If your collection supports only specific connection types (such as HTTPAPI, netconf, or others), list them here.
 -->
 
-<!-- TODO: ## Included content
+<!-- TODO| ## Included content
 Galaxy will eventually list the module docs within the UI, but until that is ready, you may need to either describe your plugins etc here, or point to an external docsite to cover that information.
 -->
 
@@ -72,7 +72,7 @@ ansible-galaxy collection install {{ cookiecutter.namespace }}.{{ cookiecutter.c
 
 See [Ansible Using collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html) for more details.
 
-<!-- TODO: ### Examples
+<!-- TODO| ### Examples
 Include some quick examples that cover the most common use cases for your collection content.
 -->{% if cookiecutter.enable_antsibull_changelog %}
 

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/galaxy.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/galaxy.yml
@@ -1,61 +1,61 @@
 ---
 # https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 
-# NOTE: The namespace of the collection.
+# NOTE| The namespace of the collection.
 namespace: "{{ cookiecutter.namespace }}"
 
-# NOTE: The name of the collection.
+# NOTE| The name of the collection.
 name: "{{ cookiecutter.collection_name }}"
 
-# NOTE: The version of the collection.
+# NOTE| The version of the collection.
 version: "{{ cookiecutter.version }}"
 
 # The path to the Markdown (.md) readme file.
 readme: README.md
 
-# NOTE: A list of the collection's content authors.
+# NOTE| A list of the collection's content authors.
 authors:
   - "{{ cookiecutter.author }}"
 
-# NOTE: A short summary description of the collection.
+# NOTE| A short summary description of the collection.
 description: "{{ cookiecutter.collection_description }}"
 
 {% if cookiecutter.license != 'none' -%}
-# NOTE: Either a single license or a list of licenses for content inside of a collection.
+# NOTE| Either a single license or a list of licenses for content inside of a collection.
 # license:
 #   - "{{ cookiecutter.license }}"
 
-# NOTE: The path to the license file for the collection.
+# NOTE| The path to the license file for the collection.
 license_file: "LICENSE"
 {%- else -%}
-# NOTE: Either a single license or a list of licenses for content inside of a collection.
+# NOTE| Either a single license or a list of licenses for content inside of a collection.
 # license:
 #   - GPL-3.0-or-later
 
-# NOTE: The path to the license file for the collection.
+# NOTE| The path to the license file for the collection.
 # license_file: ""
 {%- endif %}
 
-# NOTE: A list of tags you want to associate with the collection for indexing/searching.
+# NOTE| A list of tags you want to associate with the collection for indexing/searching.
 tags:
   - "{{ cookiecutter.tag }}"
 
-# NOTE: The list of collection dependencies this collection requires to be installed for it to be usable.
+# NOTE| The list of collection dependencies this collection requires to be installed for it to be usable.
 # dependencies: {}
 
-# NOTE: The URL of the originating SCM repository
+# NOTE| The URL of the originating SCM repository
 repository: "{{ cookiecutter.scm_repository }}"
 
-# NOTE: The URL to any online docs
+# NOTE| The URL to any online docs
 # documentation: "{{ cookiecutter.scm_repository }}/wiki"
 
-# NOTE: The URL to the homepage of the collection/project
+# NOTE| The URL to the homepage of the collection/project
 # homepage: "{{ cookiecutter.scm_repository }}"
 
-# NOTE: The URL to the collection issue tracker
+# NOTE| The URL to the collection issue tracker
 issues: "{{ cookiecutter.scm_repository }}/issues"
 
-# NOTE: The build ignore list that should not be included in the build artifact.
+# NOTE| The build ignore list that should not be included in the build artifact.
 build_ignore:
   - .gitignore
   - .github

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/playbooks/{{cookiecutter.role_name}}.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/playbooks/{{cookiecutter.role_name}}.yml
@@ -1,5 +1,5 @@
 ---
-# NOTE: {{ cookiecutter.role_name }} Default Playbook
+# NOTE|{{ cookiecutter.role_name }}| Default Playbook
 
 - name: Run {{ cookiecutter.namespace }}.{{ cookiecutter.collection_name }}.{{ cookiecutter.role_name }} # noqa: role-name[path]
   hosts: {% raw %}"{{ target | default('all') }}"{% endraw %}

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/README.md
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/README.md
@@ -2,12 +2,12 @@
 
 {{ cookiecutter.role_description }}
 
-<!-- TODO: ## Requirements
+<!-- TODO| ## Requirements
 
 Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
 -->
 
-<!-- TODO: ## Role Variables
+<!-- TODO| ## Role Variables
 
  A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
 
@@ -20,7 +20,7 @@ Another example variable.
   {{ cookiecutter.role_name }}_variable2
 -->
 
-<!-- TODO: ## Dependencies
+<!-- TODO| ## Dependencies
 
 A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
 

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/defaults/main.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-# NOTE: {{ cookiecutter.role_name }} Default Variable Definitions
+# NOTE|{{ cookiecutter.role_name }}| Default Variable Definitions
 # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-directory-structure

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/handlers/main.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-# NOTE: {{ cookiecutter.role_name }} Handlers
+# NOTE|{{ cookiecutter.role_name }}| Handlers
 # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-directory-structure

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/meta/argument_specs.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/meta/argument_specs.yml
@@ -1,7 +1,7 @@
 ---
 # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-argument-validation
 
-# NOTE: {{ cookiecutter.role_name }} argument validation
+# NOTE|{{ cookiecutter.role_name }}| Entry Point Argument Validation
 # argument_specs:
 #   main:
 #     short_description: The main entry point for the {{ cookiecutter.role_name }} role.

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/meta/main.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/meta/main.yml
@@ -2,39 +2,39 @@
 # https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#using-meta-main-yml
 
 galaxy_info:
-  # NOTE: The namespace of the role.
+  # NOTE| The namespace of the role.
   namespace: "{{ cookiecutter.namespace }}"
 
-  # NOTE: The name of the role..
+  # NOTE| The name of the role..
   role_name: "{{ cookiecutter.role_name }}"
 
-  # NOTE: A short summary description of the role.
+  # NOTE| A short summary description of the role.
   description: "{{ cookiecutter.role_description }}"
 
-  # NOTE: The company claiming ownership of the role.
+  # NOTE| The company claiming ownership of the role.
   # company: ""
 
-  # NOTE: A list of the role's content authors.
+  # NOTE| A list of the role's content authors.
   author: "{{ cookiecutter.author }}"
 
-  # NOTE: The license for content inside of a role.
+  # NOTE| The license for content inside of a role.
   license: "{{ cookiecutter.license }}"
 
-  # NOTE: The minimum Ansible version.
+  # NOTE| The minimum Ansible version.
   min_ansible_version: "{{ cookiecutter.requires_ansible_version }}"
 
-  # NOTE: The list of supported platforms
+  # NOTE| The list of supported platforms
   # platforms:
   #   - name: EL
   #     versions:
   #       - "8"
   #       - "9"
 
-  # NOTE: A list of tags (20 max) you want to associate with the role for indexing/searching.
+  # NOTE| A list of tags (20 max) you want to associate with the role for indexing/searching.
   galaxy_tags:
     - "{{ cookiecutter.tag }}"
 
-# NOTE: The list of role dependencies
+# NOTE| The list of role dependencies
 # dependencies:
 #   - role: foo
 #     vars:

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/tasks/RedHat.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/tasks/RedHat.yml
@@ -1,3 +1,3 @@
 ---
-# NOTE: {{ cookiecutter.role_name }} RHEL Tasks
+# NOTE|{{ cookiecutter.role_name }}| Tasks (RHEL)
 # https://redhat-cop.github.io/automation-good-practices/#_platform_specific_tasks

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/tasks/main.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# NOTE: {{ cookiecutter.role_name }} Tasks
+# NOTE|{{ cookiecutter.role_name }}| Tasks
 # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-directory-structure
 
 # https://redhat-cop.github.io/automation-good-practices/#_platform_specific_variables

--- a/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/vars/main.yml
+++ b/{{cookiecutter.namespace}}/{{cookiecutter.collection_name}}/roles/{{cookiecutter.role_name}}/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-directory-structure
 
-# NOTE: {{ cookiecutter.role_name }} Required Facts
+# NOTE|{{ cookiecutter.role_name }}| Required Facts
 # https://redhat-cop.github.io/automation-good-practices/#_platform_specific_variables
 __{{ cookiecutter.role_name }}_required_facts:
   - distribution


### PR DESCRIPTION
Refactored TODO comments across project to switch from a `:` to a `|` delimiter for readability within VSCode extension.